### PR TITLE
avoid JS crash

### DIFF
--- a/js/docpreview.js.php
+++ b/js/docpreview.js.php
@@ -14,11 +14,12 @@ function docPreview_set_link() {
 		if(url.indexOf('document.php?')!=-1 && url.indexOf('action=delete')==-1 && (url.toLowerCase().indexOf('.pdf')!=-1 || url.toLowerCase().indexOf('.odt')!=-1) ) {
 			filename = $(this).text();
 			if(filename == '') filename = $(this).find('img').attr('alt');
+			if(filename) {
+				url = "javascript:docPreview_pop('<?php echo dol_buildpath('/docpreview/Viewer.js/v.html',1) ?>#"+encodeURIComponent(url)+"', '"+filename.replace(/'/g, "\\'")+"')";
+				link = '&nbsp;<a href="'+url+'"><?php echo img_object($langs->trans('Preview'),'docpreview@docpreview') ?></a>';
 			
-			url = "javascript:docPreview_pop('<?php echo dol_buildpath('/docpreview/Viewer.js/v.html',1) ?>#"+encodeURIComponent(url)+"', '"+filename.replace(/'/g, "\\'")+"')";
-			link = '&nbsp;<a href="'+url+'"><?php echo img_object($langs->trans('Preview'),'docpreview@docpreview') ?></a>';
-			
-			$(this).after(link);
+				$(this).after(link);
+			}
 		}
 		
 	});


### PR DESCRIPTION
FIX : Avoid JS crash if document pdf icon do not have "alt" attribute (for exemple current version of agefodd, fix in new version (for dolibarr 3.7))